### PR TITLE
add repo URL to metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ readme = "README.md"
 license = {text = "BSD-3-Clause"}
 dynamic = ["version"]
 
+[project.urls]
+homepage = "https://github.com/ZipHQ/bar-raiser"
+
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"


### PR DESCRIPTION
## Description

Adds the GitHub repo URL to the project metadata. When released, this will now appear in the Project Details section on PyPI, which will help folks traverse from the PyPI page back to this repo if they wish to submit issues or new PRs.

## Type of change

- [x] Project metadata fix
