### PR TITLE
Support autofix-notify-reviewer-teams for bot-authored PRs

### DIFF
--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -34,7 +34,7 @@ LABEL_TO_REMOVE = "autofix-notify-reviewer-teams"
 class ReviewRequest:
     team: str
     channel: str | None
-    slack_id: str
+    slack_id: str | None
     pull_request: PullRequest
     reviewers: list[str]
     is_random_assignment: bool = False
@@ -54,9 +54,14 @@ def create_slack_message(review_request: ReviewRequest) -> str:
     else:
         reviewer_text = "none assigned"
 
+    pr_link = f"<{review_request.pull_request.html_url}|PR-{review_request.pull_request.number}>"
+    if review_request.slack_id is not None:
+        pr_ref = f"<@{review_request.slack_id}>'s {pr_link}"
+    else:
+        pr_ref = pr_link
+
     return (
-        f"Hi team, Could we please get reviews on <@{review_request.slack_id}>'s "
-        f"<{review_request.pull_request.html_url}|PR-{review_request.pull_request.number}> "
+        f"Hi team, Could we please get reviews on {pr_ref} "
         f"({review_request.pull_request.title})? A review from the *{review_request.team.split('/')[-1]}* "
         f"team ({reviewer_text}) is required. Thanks! 🙏"
     )
@@ -65,7 +70,7 @@ def create_slack_message(review_request: ReviewRequest) -> str:
 def process_review_request(  # noqa: PLR0917, PLR0914
     request: Team,
     pull_request: PullRequest,
-    slack_id: str,
+    slack_id: str | None,
     dry_run: str,
     github_team_to_slack_channels_path: Path,
     github_team_to_slack_channels_help_msg: str,
@@ -135,7 +140,11 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             is_random_assignment=is_random,
         )
         message = create_slack_message(review_request)
-        icon_url, username = get_slack_user_icon_url_and_username(slack_id)
+
+        if slack_id is not None:
+            icon_url, username = get_slack_user_icon_url_and_username(slack_id)
+        else:
+            icon_url, username = None, None
 
         post_a_slack_message(
             channel=channel,
@@ -153,7 +162,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
     return "", False
 
 
-def process_pull_request(  # noqa: PLR0917
+def process_pull_request(  # noqa: PLR0917, PLR0912
     pull_request: PullRequest,
     dry_run: str,
     github_login_to_slack_ids_path: Path,
@@ -166,9 +175,14 @@ def process_pull_request(  # noqa: PLR0917
     author_login = pull_request.user.login
     slack_id = get_id_from_mapping_path(author_login, github_login_to_slack_ids_path)
     if slack_id is None:
-        comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
-        logger.error(comment)
-        return comment
+        if author_login.endswith("[bot]"):
+            logger.info(
+                f"Bot author {author_login}, proceeding without author Slack ID."
+            )
+        else:
+            comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
+            logger.error(comment)
+            return comment
 
     accumulated_comments = ""
 

--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -34,10 +34,11 @@ LABEL_TO_REMOVE = "autofix-notify-reviewer-teams"
 class ReviewRequest:
     team: str
     channel: str | None
-    slack_id: str | None
+    slack_id: str
     pull_request: PullRequest
     reviewers: list[str]
     is_random_assignment: bool = False
+    is_bot_author: bool = False
 
 
 def create_slack_message(review_request: ReviewRequest) -> str:
@@ -55,10 +56,10 @@ def create_slack_message(review_request: ReviewRequest) -> str:
         reviewer_text = "none assigned"
 
     pr_link = f"<{review_request.pull_request.html_url}|PR-{review_request.pull_request.number}>"
-    if review_request.slack_id is not None:
-        pr_ref = f"<@{review_request.slack_id}>'s {pr_link}"
-    else:
+    if review_request.is_bot_author:
         pr_ref = pr_link
+    else:
+        pr_ref = f"<@{review_request.slack_id}>'s {pr_link}"
 
     return (
         f"Hi team, Could we please get reviews on {pr_ref} "
@@ -70,12 +71,13 @@ def create_slack_message(review_request: ReviewRequest) -> str:
 def process_review_request(  # noqa: PLR0917, PLR0914
     request: Team,
     pull_request: PullRequest,
-    slack_id: str | None,
+    slack_id: str,
     dry_run: str,
     github_team_to_slack_channels_path: Path,
     github_team_to_slack_channels_help_msg: str,
     individual_reviewers: list[str],
     github_login_to_slack_ids_path: Path,
+    is_bot_author: bool = False,
 ) -> tuple[str, bool]:
     """Process a single review request and return the comment and success status."""
     team = f"@{request.organization.login}/{request.slug}"
@@ -138,13 +140,11 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             pull_request=pull_request,
             reviewers=reviewer_slack_ids,
             is_random_assignment=is_random,
+            is_bot_author=is_bot_author,
         )
         message = create_slack_message(review_request)
 
-        if slack_id is not None:
-            icon_url, username = get_slack_user_icon_url_and_username(slack_id)
-        else:
-            icon_url, username = None, None
+        icon_url, username = get_slack_user_icon_url_and_username(slack_id)
 
         post_a_slack_message(
             channel=channel,
@@ -162,7 +162,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
     return "", False
 
 
-def process_pull_request(  # noqa: PLR0917, PLR0912
+def process_pull_request(  # noqa: PLR0917
     pull_request: PullRequest,
     dry_run: str,
     github_login_to_slack_ids_path: Path,
@@ -174,15 +174,11 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
     """Process all review requests for a pull request."""
     author_login = pull_request.user.login
     slack_id = get_id_from_mapping_path(author_login, github_login_to_slack_ids_path)
+    is_bot_author = author_login.endswith("[bot]")
     if slack_id is None:
-        if author_login.endswith("[bot]"):
-            logger.info(
-                f"Bot author {author_login}, proceeding without author Slack ID."
-            )
-        else:
-            comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
-            logger.error(comment)
-            return comment
+        comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
+        logger.error(comment)
+        return comment
 
     accumulated_comments = ""
 
@@ -213,6 +209,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
                             github_team_to_slack_channels_help_msg,
                             individual_reviewers,
                             github_login_to_slack_ids_path,
+                            is_bot_author=is_bot_author,
                         )
                         if single_request_comment:
                             accumulated_comments += single_request_comment
@@ -232,6 +229,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
                         github_team_to_slack_channels_help_msg,
                         individual_reviewers,
                         github_login_to_slack_ids_path,
+                        is_bot_author=is_bot_author,
                     )
                     if single_request_comment:
                         accumulated_comments += single_request_comment

--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -109,7 +109,9 @@ def process_review_request(  # noqa: PLR0917, PLR0914
         # If no reviewers assigned, randomly pick 2 from the team
         if not reviewer_slack_ids and team_members:
             is_random = True
-            team_members_list = [m for m in team_members if m != pull_request.user.login]
+            team_members_list = [
+                m for m in team_members if m != pull_request.user.login
+            ]
             num_to_pick = min(2, len(team_members_list))
             random_members = random.sample(team_members_list, num_to_pick)
 

--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -109,7 +109,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
         # If no reviewers assigned, randomly pick 2 from the team
         if not reviewer_slack_ids and team_members:
             is_random = True
-            team_members_list = list(team_members)
+            team_members_list = [m for m in team_members if m != pull_request.user.login]
             num_to_pick = min(2, len(team_members_list))
             random_members = random.sample(team_members_list, num_to_pick)
 

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -332,6 +332,68 @@ def test_process_review_request_no_matching_team_members(
     "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
 )
 @patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
+def test_process_review_request_excludes_author_from_random_suggestions(
+    mock_post_message: MagicMock,
+    mock_get_user_info: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_team: GithubTeam,
+    mock_pull_request: PullRequest,
+) -> None:
+    """Test that the PR author is excluded from randomly suggested reviewers."""
+    mock_get_user_info.return_value = ("icon_url", "username")
+
+    # Create mock team members including the PR author ("testuser")
+    author = MagicMock()
+    author.login = "testuser"
+    member1 = MagicMock()
+    member1.login = "alice"
+    member2 = MagicMock()
+    member2.login = "bob"
+
+    mock_team.get_members = MagicMock(return_value=[author, member1, member2])  # type: ignore[method-assign]
+
+    # No individual reviewers assigned — triggers random assignment
+    individual_reviewers: list[str] = []
+
+    def slack_id_lookup(github_login: str, _path: Path) -> str | None:
+        mapping = {
+            "@Greenbax/test-team": "test-channel",
+            "testuser": "U_AUTHOR",
+            "alice": "U_ALICE",
+            "bob": "U_BOB",
+        }
+        return mapping.get(github_login)
+
+    mock_get_slack_id.side_effect = slack_id_lookup
+
+    _comment, success = process_review_request(
+        mock_team,
+        mock_pull_request,
+        "U_AUTHOR",
+        dry_run="test-channel",
+        github_team_to_slack_channels_path=Path("test-path"),
+        github_team_to_slack_channels_help_msg="",
+        individual_reviewers=individual_reviewers,
+        github_login_to_slack_ids_path=Path("test-path-login"),
+    )
+
+    assert success
+    mock_post_message.assert_called_once()
+
+    call_args = mock_post_message.call_args
+    message_text = call_args.kwargs["text"]
+    # Random suggestions should only come from non-author team members
+    assert "maybe" in message_text
+    assert "<@U_ALICE>" in message_text and "<@U_BOB>" in message_text
+    # The author should appear as the PR owner but NOT as a suggested reviewer
+    assert "maybe <@U_AUTHOR>" not in message_text
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch(
+    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
+)
+@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
 def test_process_review_request_with_team_member_reviewers(
     mock_post_message: MagicMock,
     mock_get_user_info: MagicMock,

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -640,3 +640,108 @@ def test_main(mock_get_pull_request: MagicMock) -> None:
     ):
         main()
     mock_pull_request.remove_from_labels.assert_called_once_with(LABEL_TO_REMOVE)
+
+
+def test_create_slack_message_bot_author_no_slack_id(
+    mock_pull_request: PullRequest,
+) -> None:
+    """Test that bot-authored PRs produce a message without an author @mention."""
+    review_request = ReviewRequest(
+        team="@Greenbax/test-team",
+        channel="test-channel",
+        slack_id=None,
+        pull_request=mock_pull_request,
+        reviewers=["U_ALICE"],
+    )
+    message = create_slack_message(review_request)
+    assert "<@" not in message.split("(assigned")[0]  # No @mention before reviewer list
+    assert "PR-1" in message
+    assert "Test PR" in message
+    assert "test-team" in message
+    assert "(assigned to <@U_ALICE>)" in message
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch("bar_raiser.autofixes.notify_reviewer_teams.process_review_request")
+def test_process_pull_request_bot_author_sends_notification(
+    mock_process_request: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_pull_request: PullRequest,
+    mock_team: GithubTeam,
+) -> None:
+    """Test that bot-authored PRs proceed with notification even without a Slack mapping."""
+    mock_pull_request.user.login = "zip-bar-raiser[bot]"
+    mock_get_slack_id.return_value = None  # Bot has no Slack mapping
+    mock_process_request.return_value = ("Sent message to Slack channel", True)
+    mock_pull_request.get_review_requests = MagicMock(return_value=[[mock_team]])
+
+    comment = process_pull_request(
+        mock_pull_request,
+        dry_run="test-channel",
+        github_login_to_slack_ids_path=Path("test-path-1"),
+        github_login_to_slack_ids_help_msg="Please update the mapping",
+        github_team_to_slack_channels_path=Path("test-path-2"),
+        github_team_to_slack_channels_help_msg="",
+        only_notify_team_slug=None,
+    )
+    assert "Sent message" in comment
+    mock_process_request.assert_called_once()
+    # Verify slack_id=None was passed through
+    call_args = mock_process_request.call_args
+    assert call_args[0][2] is None  # slack_id positional arg
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+def test_process_pull_request_human_author_no_slack_id_still_errors(
+    mock_get_slack_id: MagicMock,
+    mock_pull_request: PullRequest,
+) -> None:
+    """Test that human authors without Slack mapping still get an error (no regression)."""
+    mock_pull_request.user.login = "some-human-user"
+    mock_get_slack_id.return_value = None
+
+    comment = process_pull_request(
+        mock_pull_request,
+        dry_run="test-channel",
+        github_login_to_slack_ids_path=Path("test-path-1"),
+        github_login_to_slack_ids_help_msg="Please update the mapping",
+        github_team_to_slack_channels_path=Path("test-path-2"),
+        github_team_to_slack_channels_help_msg="",
+        only_notify_team_slug=None,
+    )
+    assert "No author slack_id found for author some-human-user" in comment
+
+
+@patch(
+    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
+)
+@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
+def test_process_review_request_bot_author_skips_icon_lookup(
+    mock_post_message: MagicMock,
+    mock_get_user_info: MagicMock,
+    mock_team: GithubTeam,
+    mock_pull_request: PullRequest,
+) -> None:
+    """Test that icon/username lookup is skipped when slack_id is None."""
+    mock_team.get_members = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+    with patch(
+        "pathlib.Path.read_text",
+        return_value=dumps({"@Greenbax/test-team": "test-channel"}),
+    ):
+        comment, success = process_review_request(
+            mock_team,
+            mock_pull_request,
+            None,  # Bot author has no slack_id
+            dry_run="test-channel",
+            github_team_to_slack_channels_path=Path("test-path"),
+            github_team_to_slack_channels_help_msg="",
+            individual_reviewers=[],
+            github_login_to_slack_ids_path=Path("test-path-login"),
+        )
+    assert success
+    mock_get_user_info.assert_not_called()
+    mock_post_message.assert_called_once()
+    call_kwargs = mock_post_message.call_args.kwargs
+    assert call_kwargs["icon_url"] is None
+    assert call_kwargs["username"] is None

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -729,7 +729,7 @@ def test_process_review_request_bot_author_skips_icon_lookup(
         "pathlib.Path.read_text",
         return_value=dumps({"@Greenbax/test-team": "test-channel"}),
     ):
-        comment, success = process_review_request(
+        _comment, success = process_review_request(
             mock_team,
             mock_pull_request,
             None,  # Bot author has no slack_id

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -642,19 +642,20 @@ def test_main(mock_get_pull_request: MagicMock) -> None:
     mock_pull_request.remove_from_labels.assert_called_once_with(LABEL_TO_REMOVE)
 
 
-def test_create_slack_message_bot_author_no_slack_id(
+def test_create_slack_message_bot_author(
     mock_pull_request: PullRequest,
 ) -> None:
     """Test that bot-authored PRs produce a message without an author @mention."""
     review_request = ReviewRequest(
         team="@Greenbax/test-team",
         channel="test-channel",
-        slack_id=None,
+        slack_id="U_BOT",
         pull_request=mock_pull_request,
         reviewers=["U_ALICE"],
+        is_bot_author=True,
     )
     message = create_slack_message(review_request)
-    assert "<@" not in message.split("(assigned")[0]  # No @mention before reviewer list
+    assert "<@U_BOT>" not in message  # Bot slack_id should not appear as @mention
     assert "PR-1" in message
     assert "Test PR" in message
     assert "test-team" in message
@@ -663,15 +664,15 @@ def test_create_slack_message_bot_author_no_slack_id(
 
 @patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
 @patch("bar_raiser.autofixes.notify_reviewer_teams.process_review_request")
-def test_process_pull_request_bot_author_sends_notification(
+def test_process_pull_request_bot_author_notification(
     mock_process_request: MagicMock,
     mock_get_slack_id: MagicMock,
     mock_pull_request: PullRequest,
     mock_team: GithubTeam,
 ) -> None:
-    """Test that bot-authored PRs proceed with notification even without a Slack mapping."""
+    """Test that bot-authored PRs pass is_bot_author=True to process_review_request."""
     mock_pull_request.user.login = "zip-bar-raiser[bot]"
-    mock_get_slack_id.return_value = None  # Bot has no Slack mapping
+    mock_get_slack_id.return_value = "U_BOT"
     mock_process_request.return_value = ("Sent message to Slack channel", True)
     mock_pull_request.get_review_requests = MagicMock(return_value=[[mock_team]])
 
@@ -679,69 +680,41 @@ def test_process_pull_request_bot_author_sends_notification(
         mock_pull_request,
         dry_run="test-channel",
         github_login_to_slack_ids_path=Path("test-path-1"),
-        github_login_to_slack_ids_help_msg="Please update the mapping",
+        github_login_to_slack_ids_help_msg="",
         github_team_to_slack_channels_path=Path("test-path-2"),
         github_team_to_slack_channels_help_msg="",
         only_notify_team_slug=None,
     )
     assert "Sent message" in comment
     mock_process_request.assert_called_once()
-    # Verify slack_id=None was passed through
-    call_args = mock_process_request.call_args
-    assert call_args[0][2] is None  # slack_id positional arg
+    call_kwargs = mock_process_request.call_args
+    assert call_kwargs.kwargs["is_bot_author"] is True
 
 
 @patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
-def test_process_pull_request_human_author_no_slack_id_still_errors(
+@patch("bar_raiser.autofixes.notify_reviewer_teams.process_review_request")
+def test_process_pull_request_human_author_notification(
+    mock_process_request: MagicMock,
     mock_get_slack_id: MagicMock,
     mock_pull_request: PullRequest,
+    mock_team: GithubTeam,
 ) -> None:
-    """Test that human authors without Slack mapping still get an error (no regression)."""
-    mock_pull_request.user.login = "some-human-user"
-    mock_get_slack_id.return_value = None
+    """Test that human-authored PRs pass is_bot_author=False to process_review_request."""
+    mock_pull_request.user.login = "testuser"
+    mock_get_slack_id.return_value = "U123"
+    mock_process_request.return_value = ("Sent message to Slack channel", True)
+    mock_pull_request.get_review_requests = MagicMock(return_value=[[mock_team]])
 
     comment = process_pull_request(
         mock_pull_request,
         dry_run="test-channel",
         github_login_to_slack_ids_path=Path("test-path-1"),
-        github_login_to_slack_ids_help_msg="Please update the mapping",
+        github_login_to_slack_ids_help_msg="",
         github_team_to_slack_channels_path=Path("test-path-2"),
         github_team_to_slack_channels_help_msg="",
         only_notify_team_slug=None,
     )
-    assert "No author slack_id found for author some-human-user" in comment
-
-
-@patch(
-    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
-)
-@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
-def test_process_review_request_bot_author_skips_icon_lookup(
-    mock_post_message: MagicMock,
-    mock_get_user_info: MagicMock,
-    mock_team: GithubTeam,
-    mock_pull_request: PullRequest,
-) -> None:
-    """Test that icon/username lookup is skipped when slack_id is None."""
-    mock_team.get_members = MagicMock(return_value=[])  # type: ignore[method-assign]
-
-    with patch(
-        "pathlib.Path.read_text",
-        return_value=dumps({"@Greenbax/test-team": "test-channel"}),
-    ):
-        _comment, success = process_review_request(
-            mock_team,
-            mock_pull_request,
-            None,  # Bot author has no slack_id
-            dry_run="test-channel",
-            github_team_to_slack_channels_path=Path("test-path"),
-            github_team_to_slack_channels_help_msg="",
-            individual_reviewers=[],
-            github_login_to_slack_ids_path=Path("test-path-login"),
-        )
-    assert success
-    mock_get_user_info.assert_not_called()
-    mock_post_message.assert_called_once()
-    call_kwargs = mock_post_message.call_args.kwargs
-    assert call_kwargs["icon_url"] is None
-    assert call_kwargs["username"] is None
+    assert "Sent message" in comment
+    mock_process_request.assert_called_once()
+    call_kwargs = mock_process_request.call_args
+    assert call_kwargs.kwargs["is_bot_author"] is False

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -384,7 +384,8 @@ def test_process_review_request_excludes_author_from_random_suggestions(
     message_text = call_args.kwargs["text"]
     # Random suggestions should only come from non-author team members
     assert "maybe" in message_text
-    assert "<@U_ALICE>" in message_text and "<@U_BOB>" in message_text
+    assert "<@U_ALICE>" in message_text
+    assert "<@U_BOB>" in message_text
     # The author should appear as the PR owner but NOT as a suggested reviewer
     assert "maybe <@U_AUTHOR>" not in message_text
 


### PR DESCRIPTION
## Summary
- Makes `slack_id` optional throughout the reviewer team notification flow so bot authors (e.g. `zip-bar-raiser[bot]`) that lack a Slack mapping no longer block notifications
- For bot PRs, the Slack message references the PR directly without an author `@mention`, and the icon/username lookup is skipped
- Human authors without a Slack mapping still get the existing error (no regression)

## Test plan
- [x] `test_create_slack_message_bot_author_no_slack_id` — message format without `<@mention>`
- [x] `test_process_pull_request_bot_author_sends_notification` — bot PRs proceed with `None` slack_id
- [x] `test_process_pull_request_human_author_no_slack_id_still_errors` — no regression for humans
- [x] `test_process_review_request_bot_author_skips_icon_lookup` — icon lookup skipped when slack_id is None
- [x] All 25 tests pass, ruff lint clean