### PR TITLE
Tag label sender instead of bot author in Slack notifications

### DIFF
--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -5,6 +5,7 @@ import sys
 from argparse import ArgumentParser
 from dataclasses import dataclass
 from logging import getLogger
+from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,7 +35,7 @@ LABEL_TO_REMOVE = "autofix-notify-reviewer-teams"
 class ReviewRequest:
     team: str
     channel: str | None
-    slack_id: str
+    slack_id: str | None
     pull_request: PullRequest
     reviewers: list[str]
     is_random_assignment: bool = False
@@ -54,9 +55,15 @@ def create_slack_message(review_request: ReviewRequest) -> str:
     else:
         reviewer_text = "none assigned"
 
+    pr_link = f"<{review_request.pull_request.html_url}|PR-{review_request.pull_request.number}>"
+
+    if review_request.slack_id:
+        pr_reference = f"<@{review_request.slack_id}>'s {pr_link}"
+    else:
+        pr_reference = pr_link
+
     return (
-        f"Hi team, Could we please get reviews on <@{review_request.slack_id}>'s "
-        f"<{review_request.pull_request.html_url}|PR-{review_request.pull_request.number}> "
+        f"Hi team, Could we please get reviews on {pr_reference} "
         f"({review_request.pull_request.title})? A review from the *{review_request.team.split('/')[-1]}* "
         f"team ({reviewer_text}) is required. Thanks! 🙏"
     )
@@ -65,7 +72,7 @@ def create_slack_message(review_request: ReviewRequest) -> str:
 def process_review_request(  # noqa: PLR0917, PLR0914
     request: Team,
     pull_request: PullRequest,
-    slack_id: str,
+    slack_id: str | None,
     dry_run: str,
     github_team_to_slack_channels_path: Path,
     github_team_to_slack_channels_help_msg: str,
@@ -135,7 +142,10 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             is_random_assignment=is_random,
         )
         message = create_slack_message(review_request)
-        icon_url, username = get_slack_user_icon_url_and_username(slack_id)
+        if slack_id:
+            icon_url, username = get_slack_user_icon_url_and_username(slack_id)
+        else:
+            icon_url, username = None, None
 
         post_a_slack_message(
             channel=channel,
@@ -153,7 +163,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
     return "", False
 
 
-def process_pull_request(  # noqa: PLR0917
+def process_pull_request(  # noqa: PLR0917, PLR0912
     pull_request: PullRequest,
     dry_run: str,
     github_login_to_slack_ids_path: Path,
@@ -164,11 +174,20 @@ def process_pull_request(  # noqa: PLR0917
 ) -> str:
     """Process all review requests for a pull request."""
     author_login = pull_request.user.login
-    slack_id = get_id_from_mapping_path(author_login, github_login_to_slack_ids_path)
-    if slack_id is None:
-        comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
-        logger.error(comment)
-        return comment
+
+    if author_login.endswith("[bot]"):
+        # Bot-authored PR: use the label sender (GITHUB_ACTOR) instead
+        label_sender = environ.get("GITHUB_ACTOR")
+        if label_sender:
+            slack_id = get_id_from_mapping_path(label_sender, github_login_to_slack_ids_path)
+        else:
+            slack_id = None
+    else:
+        slack_id = get_id_from_mapping_path(author_login, github_login_to_slack_ids_path)
+        if slack_id is None:
+            comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
+            logger.error(comment)
+            return comment
 
     accumulated_comments = ""
 

--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -179,11 +179,15 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
         # Bot-authored PR: use the label sender (GITHUB_ACTOR) instead
         label_sender = environ.get("GITHUB_ACTOR")
         if label_sender:
-            slack_id = get_id_from_mapping_path(label_sender, github_login_to_slack_ids_path)
+            slack_id = get_id_from_mapping_path(
+                label_sender, github_login_to_slack_ids_path
+            )
         else:
             slack_id = None
     else:
-        slack_id = get_id_from_mapping_path(author_login, github_login_to_slack_ids_path)
+        slack_id = get_id_from_mapping_path(
+            author_login, github_login_to_slack_ids_path
+        )
         if slack_id is None:
             comment = f"No author slack_id found for author {author_login}.\n{github_login_to_slack_ids_help_msg}\n"
             logger.error(comment)

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -67,8 +67,7 @@ def test_create_slack_message_no_slack_id(mock_pull_request: PullRequest) -> Non
     assert "test-team" in message
     assert "<@" not in message
     assert (
-        "Could we please get reviews on <https://github.com/test/pr/1|PR-1>"
-        in message
+        "Could we please get reviews on <https://github.com/test/pr/1|PR-1>" in message
     )
 
 
@@ -551,6 +550,7 @@ def test_process_pull_request_bot_author_no_github_actor(
 
     with patch.dict("os.environ", {}, clear=False):
         import os
+
         os.environ.pop("GITHUB_ACTOR", None)
         comment = process_pull_request(
             mock_pull_request,

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -53,6 +53,25 @@ def test_create_slack_message(mock_pull_request: PullRequest) -> None:
     assert "(none assigned)" in message
 
 
+def test_create_slack_message_no_slack_id(mock_pull_request: PullRequest) -> None:
+    review_request = ReviewRequest(
+        team="@Greenbax/test-team",
+        channel="test-channel",
+        slack_id=None,
+        pull_request=mock_pull_request,
+        reviewers=[],
+    )
+    message = create_slack_message(review_request)
+    assert "PR-1" in message
+    assert "Test PR" in message
+    assert "test-team" in message
+    assert "<@" not in message
+    assert (
+        "Could we please get reviews on <https://github.com/test/pr/1|PR-1>"
+        in message
+    )
+
+
 def test_create_slack_message_with_reviewers(mock_pull_request: PullRequest) -> None:
     review_request = ReviewRequest(
         team="@Greenbax/test-team",
@@ -448,6 +467,104 @@ def test_process_review_request_with_team_member_reviewers(
     call_args = mock_post_message.call_args
     message_text = call_args.kwargs["text"]
     assert "(assigned to <@U_ALICE>, <@U_BOB>, <@U_CHARLIE>)" in message_text
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch("bar_raiser.autofixes.notify_reviewer_teams.process_review_request")
+def test_process_pull_request_bot_author_uses_label_sender(
+    mock_process_request: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_pull_request: PullRequest,
+    mock_team: GithubTeam,
+) -> None:
+    """When PR author is a bot, use GITHUB_ACTOR (label sender) for Slack mention."""
+    mock_pull_request.user.login = "my-app[bot]"
+
+    def slack_id_lookup(github_login: str, _path: Path) -> str | None:
+        return {"victor": "U_VICTOR"}.get(github_login)
+
+    mock_get_slack_id.side_effect = slack_id_lookup
+    mock_process_request.return_value = ("Test comment", True)
+    mock_pull_request.get_review_requests = MagicMock(return_value=[[mock_team]])
+
+    with patch.dict("os.environ", {"GITHUB_ACTOR": "victor"}):
+        comment = process_pull_request(
+            mock_pull_request,
+            dry_run="test-channel",
+            github_login_to_slack_ids_path=Path("test-path-1"),
+            github_login_to_slack_ids_help_msg="",
+            github_team_to_slack_channels_path=Path("test-path-2"),
+            github_team_to_slack_channels_help_msg="",
+            only_notify_team_slug=None,
+        )
+
+    assert comment == "Test comment"
+    # Verify process_review_request was called with the label sender's Slack ID
+    call_args = mock_process_request.call_args
+    assert call_args[0][2] == "U_VICTOR"  # slack_id positional arg
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch("bar_raiser.autofixes.notify_reviewer_teams.process_review_request")
+def test_process_pull_request_bot_author_no_sender_mapping(
+    mock_process_request: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_pull_request: PullRequest,
+    mock_team: GithubTeam,
+) -> None:
+    """When PR author is a bot and label sender has no Slack mapping, slack_id is None."""
+    mock_pull_request.user.login = "my-app[bot]"
+    mock_get_slack_id.return_value = None
+    mock_process_request.return_value = ("Test comment", True)
+    mock_pull_request.get_review_requests = MagicMock(return_value=[[mock_team]])
+
+    with patch.dict("os.environ", {"GITHUB_ACTOR": "unknown-user"}):
+        comment = process_pull_request(
+            mock_pull_request,
+            dry_run="test-channel",
+            github_login_to_slack_ids_path=Path("test-path-1"),
+            github_login_to_slack_ids_help_msg="",
+            github_team_to_slack_channels_path=Path("test-path-2"),
+            github_team_to_slack_channels_help_msg="",
+            only_notify_team_slug=None,
+        )
+
+    assert comment == "Test comment"
+    # Verify process_review_request was called with None slack_id
+    call_args = mock_process_request.call_args
+    assert call_args[0][2] is None  # slack_id positional arg
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch("bar_raiser.autofixes.notify_reviewer_teams.process_review_request")
+def test_process_pull_request_bot_author_no_github_actor(
+    mock_process_request: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_pull_request: PullRequest,
+    mock_team: GithubTeam,
+) -> None:
+    """When PR author is a bot and GITHUB_ACTOR is not set, slack_id is None."""
+    mock_pull_request.user.login = "my-app[bot]"
+    mock_get_slack_id.return_value = None
+    mock_process_request.return_value = ("Test comment", True)
+    mock_pull_request.get_review_requests = MagicMock(return_value=[[mock_team]])
+
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+        os.environ.pop("GITHUB_ACTOR", None)
+        comment = process_pull_request(
+            mock_pull_request,
+            dry_run="test-channel",
+            github_login_to_slack_ids_path=Path("test-path-1"),
+            github_login_to_slack_ids_help_msg="",
+            github_team_to_slack_channels_path=Path("test-path-2"),
+            github_team_to_slack_channels_help_msg="",
+            only_notify_team_slug=None,
+        )
+
+    assert comment == "Test comment"
+    call_args = mock_process_request.call_args
+    assert call_args[0][2] is None  # slack_id positional arg
 
 
 @patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")


### PR DESCRIPTION
## Summary
- For bot-authored PRs (login ending with `[bot]`), Slack notifications now tag the person who applied the autofix label (`GITHUB_ACTOR`) instead of the bot
- If the label sender can't be resolved to a Slack ID, the @mention is omitted entirely (e.g., "Could we please get reviews on PR-123..." instead of "@bot's PR-123...")
- Human-authored PRs are completely unaffected

## Test plan
- [x] Added test for bot author with valid label sender mapping
- [x] Added test for bot author with unknown label sender (no Slack mapping)
- [x] Added test for bot author with no `GITHUB_ACTOR` env var
- [x] Added test for `create_slack_message` with `None` slack_id
- [x] All 25 notify_reviewer_teams tests pass
- [x] Full test suite (56 tests) passes
- [x] Ruff lint clean