### PR TITLE
Add optional per-team summary to review notifications

### DIFF
--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -39,6 +39,7 @@ class ReviewRequest:
     pull_request: PullRequest
     reviewers: list[str]
     is_random_assignment: bool = False
+    summary: str | None = None
 
 
 def create_slack_message(review_request: ReviewRequest) -> str:
@@ -62,11 +63,16 @@ def create_slack_message(review_request: ReviewRequest) -> str:
     else:
         pr_reference = pr_link
 
-    return (
+    message = (
         f"Hi team, Could we please get reviews on {pr_reference} "
         f"({review_request.pull_request.title})? A review from the *{review_request.team.split('/')[-1]}* "
         f"team ({reviewer_text}) is required. Thanks! 🙏"
     )
+
+    if review_request.summary:
+        message += f"\n{review_request.summary}"
+
+    return message
 
 
 def process_review_request(  # noqa: PLR0917, PLR0914
@@ -78,6 +84,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
     github_team_to_slack_channels_help_msg: str,
     individual_reviewers: list[str],
     github_login_to_slack_ids_path: Path,
+    summary_json_path: Path | None = None,
 ) -> tuple[str, bool]:
     """Process a single review request and return the comment and success status."""
     team = f"@{request.organization.login}/{request.slug}"
@@ -133,6 +140,12 @@ def process_review_request(  # noqa: PLR0917, PLR0914
                 f"Randomly assigned {len(reviewer_slack_ids)} reviewers from team {team}"
             )
 
+        summary = (
+            get_id_from_mapping_path(team, summary_json_path)
+            if summary_json_path is not None
+            else None
+        )
+
         review_request = ReviewRequest(
             team=team,
             channel=channel,
@@ -140,6 +153,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             pull_request=pull_request,
             reviewers=reviewer_slack_ids,
             is_random_assignment=is_random,
+            summary=summary,
         )
         message = create_slack_message(review_request)
         if slack_id:
@@ -171,6 +185,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
     github_team_to_slack_channels_path: Path,
     github_team_to_slack_channels_help_msg: str,
     only_notify_team_slug: str | None,
+    summary_json_path: Path | None = None,
 ) -> str:
     """Process all review requests for a pull request."""
     author_login = pull_request.user.login
@@ -222,6 +237,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
                             github_team_to_slack_channels_help_msg,
                             individual_reviewers,
                             github_login_to_slack_ids_path,
+                            summary_json_path,
                         )
                         if single_request_comment:
                             accumulated_comments += single_request_comment
@@ -241,6 +257,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
                         github_team_to_slack_channels_help_msg,
                         individual_reviewers,
                         github_login_to_slack_ids_path,
+                        summary_json_path,
                     )
                     if single_request_comment:
                         accumulated_comments += single_request_comment
@@ -290,6 +307,16 @@ def main() -> None:
         help="Only send notification to the specific team slug if they are a requested reviewer.",
         default=None,
     )
+    parser.add_argument(
+        "--summary-json-path",
+        type=Path,
+        help=(
+            "Optional path to a JSON file mapping a GitHub team (e.g. "
+            "'@org/slug') to a summary string. When provided, the summary is "
+            "appended to that team's Slack message verbatim."
+        ),
+        default=None,
+    )
     args = parser.parse_args()
     pull = get_pull_request()
     dry_run = args.dry_run
@@ -311,6 +338,7 @@ def main() -> None:
             args.github_team_to_slack_channels,
             args.github_team_to_slack_channels_help_msg,
             args.only_notify_team,
+            args.summary_json_path,
         )
 
     if comment:

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -53,6 +53,32 @@ def test_create_slack_message(mock_pull_request: PullRequest) -> None:
     assert "(none assigned)" in message
 
 
+def test_create_slack_message_with_summary(mock_pull_request: PullRequest) -> None:
+    review_request = ReviewRequest(
+        team="@Greenbax/test-team",
+        channel="test-channel",
+        slack_id="U123",
+        pull_request=mock_pull_request,
+        reviewers=[],
+        summary="Added a feature flag constant.",
+    )
+    message = create_slack_message(review_request)
+    # The summary is appended verbatim; the caller decides any prefix/wording.
+    assert message.endswith("\nAdded a feature flag constant.")
+
+
+def test_create_slack_message_without_summary(mock_pull_request: PullRequest) -> None:
+    review_request = ReviewRequest(
+        team="@Greenbax/test-team",
+        channel="test-channel",
+        slack_id="U123",
+        pull_request=mock_pull_request,
+        reviewers=[],
+    )
+    message = create_slack_message(review_request)
+    assert message.endswith("Thanks! 🙏")
+
+
 def test_create_slack_message_no_slack_id(mock_pull_request: PullRequest) -> None:
     review_request = ReviewRequest(
         team="@Greenbax/test-team",
@@ -151,6 +177,42 @@ def test_process_review_request_success(
     assert success
     assert "test-channel" in comment
     mock_post_message.assert_called_once()
+
+
+@patch(
+    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
+)
+@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
+def test_process_review_request_appends_summary(
+    mock_post_message: MagicMock,
+    mock_get_user_info: MagicMock,
+    mock_team: GithubTeam,
+    mock_pull_request: PullRequest,
+) -> None:
+    mock_get_user_info.return_value = ("icon_url", "username")
+    mock_team.get_members = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+    def read_text(self: Path) -> str:
+        if str(self) == "summaries-path":
+            return dumps({"@Greenbax/test-team": "Bumped the dependency lockfile."})
+        return dumps({"@Greenbax/test-team": "test-channel"})
+
+    with patch("pathlib.Path.read_text", read_text):
+        _comment, success = process_review_request(
+            mock_team,
+            mock_pull_request,
+            "U123",
+            dry_run="test-channel",
+            github_team_to_slack_channels_path=Path("test-path"),
+            github_team_to_slack_channels_help_msg="",
+            individual_reviewers=[],
+            github_login_to_slack_ids_path=Path("test-path-login"),
+            summary_json_path=Path("summaries-path"),
+        )
+
+    assert success
+    message_text = mock_post_message.call_args.kwargs["text"]
+    assert message_text.endswith("\nBumped the dependency lockfile.")
 
 
 @patch(


### PR DESCRIPTION
## Summary

Adds an optional `--summary-json-path` argument to `notify_reviewer_teams`. When provided, it maps a GitHub team (`@org/slug`) to a summary string that gets appended verbatim to that team's Slack review request.

```
Hi team, Could we please get reviews on @author's PR-123 (Title)? A review
from the *p2p-global-payments* team (maybe @alice or @bob) is required. Thanks\! 🙏
Your team's changes: Added a GP-owned feature flag constant.
```

Today every tagged team sees the same generic message regardless of what part of the PR they own. With a per-team summary, a reviewer knows why they were tagged before opening the diff.

Per your review, this is summary-only: bar-raiser stays agnostic about how the summary is produced and worded, the caller generates the JSON (the same way it already takes the channel and login mappings as JSON paths), and the string is appended verbatim. The git-blame reviewer suggestion lives in evergreen.

### What's in the PR

`ReviewRequest` gains an optional `summary` field; `create_slack_message` appends it when set. `--summary-json-path` is threaded through `process_pull_request` / `process_review_request`, keyed per team via the existing `get_id_from_mapping_path` helper. Missing file or key leaves the message unchanged.

## Test plan

New tests cover the summary present, summary absent, and the per-team lookup in `process_review_request`. Full suite passes (59), ruff and pyright clean.

(Recreated from #19 with the branch on ZipHQ/bar-raiser so CI can access repo secrets; fork-based PRs cannot.)
