### PR TITLE
Support pre-computed suggested reviewers (e.g. git blame)

### DIFF
--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -4,6 +4,7 @@ import random
 import sys
 from argparse import ArgumentParser
 from dataclasses import dataclass
+from json import loads
 from logging import getLogger
 from os import environ
 from pathlib import Path
@@ -39,6 +40,7 @@ class ReviewRequest:
     pull_request: PullRequest
     reviewers: list[str]
     is_random_assignment: bool = False
+    is_blame_suggestion: bool = False
     summary: str | None = None
 
 
@@ -47,7 +49,14 @@ def create_slack_message(review_request: ReviewRequest) -> str:
     if review_request.reviewers:
         reviewer_mentions = [f"<@{reviewer}>" for reviewer in review_request.reviewers]
 
-        if review_request.is_random_assignment:
+        if review_request.is_blame_suggestion:
+            # Suggested from git blame: "maybe @alice or @bob since they
+            # recently touched these lines"
+            reviewer_text = (
+                f"maybe {' or '.join(reviewer_mentions)} "
+                "since they recently touched these lines"
+            )
+        elif review_request.is_random_assignment:
             # Randomly assigned reviewers: "maybe @alice or @bob"
             reviewer_text = f"maybe {' or '.join(reviewer_mentions)}"
         else:
@@ -75,6 +84,23 @@ def create_slack_message(review_request: ReviewRequest) -> str:
     return message
 
 
+def get_suggested_reviewers_for_team(
+    team: str, suggested_reviewers_json_path: Path | None
+) -> list[str]:
+    """Return pre-computed suggested reviewer logins for a team, if any.
+
+    The JSON maps a GitHub team (``@org/slug``) to a list of GitHub logins
+    (e.g. from git blame). Returns an empty list when the file or key is
+    absent so the caller falls back to the random pick.
+    """
+    if suggested_reviewers_json_path is None:
+        return []
+    mapping: dict[str, list[str]] = loads(  # noqa: PLW1514
+        suggested_reviewers_json_path.read_text()
+    )
+    return mapping.get(team, [])
+
+
 def process_review_request(  # noqa: PLR0917, PLR0914
     request: Team,
     pull_request: PullRequest,
@@ -85,6 +111,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
     individual_reviewers: list[str],
     github_login_to_slack_ids_path: Path,
     summary_json_path: Path | None = None,
+    suggested_reviewers_json_path: Path | None = None,
 ) -> tuple[str, bool]:
     """Process a single review request and return the comment and success status."""
     team = f"@{request.organization.login}/{request.slug}"
@@ -117,28 +144,40 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             if reviewer_slack_id:
                 reviewer_slack_ids.append(reviewer_slack_id)
 
-        # Track if we are doing random assignment
+        # Track how reviewers were chosen, which changes the message wording.
         is_random = False
+        is_blame_suggestion = False
 
-        # If no reviewers assigned, randomly pick 2 from the team
+        # If no reviewers assigned, prefer pre-computed suggestions (e.g. from
+        # git blame), filtered to current team members; otherwise pick randomly.
         if not reviewer_slack_ids and team_members:
-            is_random = True
             team_members_list = [
                 m for m in team_members if m != pull_request.user.login
             ]
-            num_to_pick = min(2, len(team_members_list))
-            random_members = random.sample(team_members_list, num_to_pick)
+            suggested = [
+                login
+                for login in get_suggested_reviewers_for_team(
+                    team, suggested_reviewers_json_path
+                )
+                if login in team_members and login != pull_request.user.login
+            ]
 
-            for github_login in random_members:
+            if suggested:
+                is_blame_suggestion = True
+                chosen = suggested
+                logger.info(f"Suggested reviewers from team {team} via git blame")
+            else:
+                is_random = True
+                num_to_pick = min(2, len(team_members_list))
+                chosen = random.sample(team_members_list, num_to_pick)
+                logger.info(f"Randomly suggested reviewers from team {team}")
+
+            for github_login in chosen:
                 reviewer_slack_id = get_id_from_mapping_path(
                     github_login, github_login_to_slack_ids_path
                 )
                 if reviewer_slack_id:
                     reviewer_slack_ids.append(reviewer_slack_id)
-
-            logger.info(
-                f"Randomly assigned {len(reviewer_slack_ids)} reviewers from team {team}"
-            )
 
         summary = (
             get_id_from_mapping_path(team, summary_json_path)
@@ -153,6 +192,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             pull_request=pull_request,
             reviewers=reviewer_slack_ids,
             is_random_assignment=is_random,
+            is_blame_suggestion=is_blame_suggestion,
             summary=summary,
         )
         message = create_slack_message(review_request)
@@ -186,6 +226,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
     github_team_to_slack_channels_help_msg: str,
     only_notify_team_slug: str | None,
     summary_json_path: Path | None = None,
+    suggested_reviewers_json_path: Path | None = None,
 ) -> str:
     """Process all review requests for a pull request."""
     author_login = pull_request.user.login
@@ -238,6 +279,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
                             individual_reviewers,
                             github_login_to_slack_ids_path,
                             summary_json_path,
+                            suggested_reviewers_json_path,
                         )
                         if single_request_comment:
                             accumulated_comments += single_request_comment
@@ -258,6 +300,7 @@ def process_pull_request(  # noqa: PLR0917, PLR0912
                         individual_reviewers,
                         github_login_to_slack_ids_path,
                         summary_json_path,
+                        suggested_reviewers_json_path,
                     )
                     if single_request_comment:
                         accumulated_comments += single_request_comment
@@ -317,6 +360,18 @@ def main() -> None:
         ),
         default=None,
     )
+    parser.add_argument(
+        "--suggested-reviewers-json",
+        type=Path,
+        help=(
+            "Optional path to a JSON file mapping a GitHub team (e.g. "
+            "'@org/slug') to a list of GitHub logins to suggest as reviewers "
+            "(e.g. from git blame). When a team has suggestions and no explicit "
+            "reviewer, these are used instead of a random pick and the message "
+            "reads 'maybe @x or @y since they recently touched these lines'."
+        ),
+        default=None,
+    )
     args = parser.parse_args()
     pull = get_pull_request()
     dry_run = args.dry_run
@@ -339,6 +394,7 @@ def main() -> None:
             args.github_team_to_slack_channels_help_msg,
             args.only_notify_team,
             args.summary_json_path,
+            args.suggested_reviewers_json,
         )
 
     if comment:

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -13,6 +13,7 @@ from bar_raiser.autofixes.notify_reviewer_teams import (
     LABEL_TO_REMOVE,
     ReviewRequest,
     create_slack_message,
+    get_suggested_reviewers_for_team,
     main,
     process_pull_request,
     process_review_request,
@@ -133,6 +134,24 @@ def test_create_slack_message_with_random_reviewers(
     assert "(maybe <@U_ALICE> or <@U_BOB>)" in message
 
 
+def test_create_slack_message_with_blame_suggestion(
+    mock_pull_request: PullRequest,
+) -> None:
+    review_request = ReviewRequest(
+        team="@Greenbax/test-team",
+        channel="test-channel",
+        slack_id="U123",
+        pull_request=mock_pull_request,
+        reviewers=["U_ALICE", "U_BOB"],
+        is_blame_suggestion=True,
+    )
+    message = create_slack_message(review_request)
+    assert (
+        "(maybe <@U_ALICE> or <@U_BOB> since they recently touched these lines)"
+        in message
+    )
+
+
 def test_create_slack_message_with_single_reviewer(
     mock_pull_request: PullRequest,
 ) -> None:
@@ -213,6 +232,77 @@ def test_process_review_request_appends_summary(
     assert success
     message_text = mock_post_message.call_args.kwargs["text"]
     assert message_text.endswith("\nBumped the dependency lockfile.")
+
+
+def test_get_suggested_reviewers_for_team() -> None:
+    with patch(
+        "pathlib.Path.read_text",
+        return_value=dumps({"@Greenbax/test-team": ["alice", "bob"]}),
+    ):
+        assert get_suggested_reviewers_for_team(
+            "@Greenbax/test-team", Path("suggested.json")
+        ) == ["alice", "bob"]
+        assert (
+            get_suggested_reviewers_for_team("@Greenbax/other", Path("suggested.json"))
+            == []
+        )
+    assert get_suggested_reviewers_for_team("@Greenbax/test-team", None) == []
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch(
+    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
+)
+@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
+@patch("bar_raiser.autofixes.notify_reviewer_teams.random.sample")
+def test_process_review_request_prefers_suggested_over_random(  # noqa: PLR0917
+    mock_random: MagicMock,
+    mock_post_message: MagicMock,
+    mock_get_user_info: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_team: GithubTeam,
+    mock_pull_request: PullRequest,
+) -> None:
+    """Suggested reviewers (e.g. from blame) are used instead of a random pick."""
+    mock_get_user_info.return_value = ("icon_url", "username")
+
+    member1 = MagicMock()
+    member1.login = "alice"
+    member2 = MagicMock()
+    member2.login = "bob"
+    mock_team.get_members = MagicMock(return_value=[member1, member2])  # type: ignore[method-assign]
+
+    def slack_id_lookup(github_login: str, _path: Path) -> str | None:
+        return {
+            "@Greenbax/test-team": "test-channel",
+            "alice": "U_ALICE",
+            "bob": "U_BOB",
+        }.get(github_login)
+
+    mock_get_slack_id.side_effect = slack_id_lookup
+
+    with patch(
+        "bar_raiser.autofixes.notify_reviewer_teams.get_suggested_reviewers_for_team",
+        return_value=["alice"],
+    ):
+        _comment, success = process_review_request(
+            mock_team,
+            mock_pull_request,
+            "U123",
+            dry_run="test-channel",
+            github_team_to_slack_channels_path=Path("test-path"),
+            github_team_to_slack_channels_help_msg="",
+            individual_reviewers=[],
+            github_login_to_slack_ids_path=Path("test-path-login"),
+            suggested_reviewers_json_path=Path("suggested.json"),
+        )
+
+    assert success
+    mock_random.assert_not_called()
+    message_text = mock_post_message.call_args.kwargs["text"]
+    assert "since they recently touched these lines" in message_text
+    assert "<@U_ALICE>" in message_text
+    assert "U_BOB" not in message_text
 
 
 @patch(


### PR DESCRIPTION
## Summary

Adds an optional `--suggested-reviewers-json` argument to `notify_reviewer_teams`: a JSON mapping from a GitHub team (`@org/slug`) to a list of GitHub logins to suggest as reviewers.

When a team has suggestions and no explicit reviewer, those are used instead of the random pick (filtered to current team members, excluding the PR author), and the message reads:

```
A review from the *p2p-global-payments* team
(maybe @alice or @bob since they recently touched these lines) is required.
```

This is the reviewer-routing half of the team-change-summary work. It keeps bar-raiser agnostic about how the suggestions are produced: the caller computes them (in our case from git blame in evergreen) and passes the JSON, the same way bar-raiser already takes the channel, login, and summary mappings as paths. Falls back to the existing random pick when a team has no suggestions.

### What's in the PR

`ReviewRequest` gains an `is_blame_suggestion` flag; `create_slack_message` renders the "since they recently touched these lines" wording when set. `get_suggested_reviewers_for_team` reads the mapping, threaded through `process_pull_request` / `process_review_request` via `--suggested-reviewers-json`. The random pick remains the fallback.

## Test plan

New tests cover the blame-suggestion message wording, the mapping reader, and `process_review_request` preferring suggestions over a random pick. Full suite passes (62), ruff and pyright clean.
