### PR TITLE
Override assigned reviewer with git blame when available

### DIFF
--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -42,10 +42,6 @@ class ReviewRequest:
     is_random_assignment: bool = False
     is_blame_suggestion: bool = False
     summary: str | None = None
-    # Slack IDs from git blame to surface as a secondary "recently touched"
-    # note alongside explicitly assigned reviewers. Empty when blame is already
-    # the primary suggestion (is_blame_suggestion) or when there are none.
-    blame_reviewers: list[str] | None = None
 
 
 def create_slack_message(review_request: ReviewRequest) -> str:
@@ -81,10 +77,6 @@ def create_slack_message(review_request: ReviewRequest) -> str:
         f"({review_request.pull_request.title})? A review from the *{review_request.team.split('/')[-1]}* "
         f"team ({reviewer_text}) is required. Thanks! 🙏"
     )
-
-    if review_request.blame_reviewers:
-        blame_mentions = [f"<@{r}>" for r in review_request.blame_reviewers]
-        message += f"\n{' or '.join(blame_mentions)} recently touched these lines."
 
     if review_request.summary:
         message += f"\n{review_request.summary}"
@@ -137,20 +129,7 @@ def process_review_request(  # noqa: PLR0912, PLR0914, PLR0917
         channel = dry_run
 
     if channel:
-        # Filter reviewers to only include members of this team
         team_members = {member.login for member in request.get_members()}
-        filtered_github_reviewers = [
-            r for r in individual_reviewers if r in team_members
-        ]
-
-        # Convert GitHub logins to Slack IDs
-        reviewer_slack_ids: list[str] = []
-        for github_login in filtered_github_reviewers:
-            reviewer_slack_id = get_id_from_mapping_path(
-                github_login, github_login_to_slack_ids_path
-            )
-            if reviewer_slack_id:
-                reviewer_slack_ids.append(reviewer_slack_id)
 
         # git-blame suggestions for this team, filtered to current members and
         # excluding the PR author.
@@ -165,40 +144,38 @@ def process_review_request(  # noqa: PLR0912, PLR0914, PLR0917
         # Track how reviewers were chosen, which changes the message wording.
         is_random = False
         is_blame_suggestion = False
-        blame_reviewer_slack_ids: list[str] = []
 
-        if reviewer_slack_ids:
-            # Reviewers are explicitly assigned. Keep them as the primary
-            # mention and surface blame suggestions as a secondary note, minus
-            # anyone already assigned.
-            assigned = set(reviewer_slack_ids)
-            for github_login in suggested:
-                blame_slack_id = get_id_from_mapping_path(
-                    github_login, github_login_to_slack_ids_path
-                )
-                if blame_slack_id and blame_slack_id not in assigned:
-                    blame_reviewer_slack_ids.append(blame_slack_id)
-        elif team_members:
-            # No reviewers assigned: prefer blame suggestions, else random pick.
-            team_members_list = [
-                m for m in team_members if m != pull_request.user.login
-            ]
-            if suggested:
-                is_blame_suggestion = True
-                chosen = suggested
-                logger.info(f"Suggested reviewers from team {team} via git blame")
-            else:
+        # Reviewer precedence: git blame > GitHub's assigned reviewers > random.
+        # Blame overrides the assigned reviewers because GitHub auto-assignment
+        # is round-robin/random and weaker than "who last touched these lines";
+        # the assigned reviewer already got GitHub's notification and any team
+        # member's approval satisfies the CODEOWNERS requirement anyway.
+        if suggested:
+            is_blame_suggestion = True
+            chosen = suggested
+            logger.info(f"Suggested reviewers from team {team} via git blame")
+        else:
+            assigned = [r for r in individual_reviewers if r in team_members]
+            if assigned:
+                chosen = assigned
+            elif team_members:
                 is_random = True
+                team_members_list = [
+                    m for m in team_members if m != pull_request.user.login
+                ]
                 num_to_pick = min(2, len(team_members_list))
                 chosen = random.sample(team_members_list, num_to_pick)
                 logger.info(f"Randomly suggested reviewers from team {team}")
+            else:
+                chosen = []
 
-            for github_login in chosen:
-                reviewer_slack_id = get_id_from_mapping_path(
-                    github_login, github_login_to_slack_ids_path
-                )
-                if reviewer_slack_id:
-                    reviewer_slack_ids.append(reviewer_slack_id)
+        reviewer_slack_ids: list[str] = []
+        for github_login in chosen:
+            reviewer_slack_id = get_id_from_mapping_path(
+                github_login, github_login_to_slack_ids_path
+            )
+            if reviewer_slack_id:
+                reviewer_slack_ids.append(reviewer_slack_id)
 
         summary = (
             get_id_from_mapping_path(team, summary_json_path)
@@ -215,7 +192,6 @@ def process_review_request(  # noqa: PLR0912, PLR0914, PLR0917
             is_random_assignment=is_random,
             is_blame_suggestion=is_blame_suggestion,
             summary=summary,
-            blame_reviewers=blame_reviewer_slack_ids,
         )
         message = create_slack_message(review_request)
         if slack_id:

--- a/src/bar_raiser/autofixes/notify_reviewer_teams.py
+++ b/src/bar_raiser/autofixes/notify_reviewer_teams.py
@@ -42,6 +42,10 @@ class ReviewRequest:
     is_random_assignment: bool = False
     is_blame_suggestion: bool = False
     summary: str | None = None
+    # Slack IDs from git blame to surface as a secondary "recently touched"
+    # note alongside explicitly assigned reviewers. Empty when blame is already
+    # the primary suggestion (is_blame_suggestion) or when there are none.
+    blame_reviewers: list[str] | None = None
 
 
 def create_slack_message(review_request: ReviewRequest) -> str:
@@ -78,6 +82,10 @@ def create_slack_message(review_request: ReviewRequest) -> str:
         f"team ({reviewer_text}) is required. Thanks! 🙏"
     )
 
+    if review_request.blame_reviewers:
+        blame_mentions = [f"<@{r}>" for r in review_request.blame_reviewers]
+        message += f"\n{' or '.join(blame_mentions)} recently touched these lines."
+
     if review_request.summary:
         message += f"\n{review_request.summary}"
 
@@ -101,7 +109,7 @@ def get_suggested_reviewers_for_team(
     return mapping.get(team, [])
 
 
-def process_review_request(  # noqa: PLR0917, PLR0914
+def process_review_request(  # noqa: PLR0912, PLR0914, PLR0917
     request: Team,
     pull_request: PullRequest,
     slack_id: str | None,
@@ -144,24 +152,37 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             if reviewer_slack_id:
                 reviewer_slack_ids.append(reviewer_slack_id)
 
+        # git-blame suggestions for this team, filtered to current members and
+        # excluding the PR author.
+        suggested = [
+            login
+            for login in get_suggested_reviewers_for_team(
+                team, suggested_reviewers_json_path
+            )
+            if login in team_members and login != pull_request.user.login
+        ]
+
         # Track how reviewers were chosen, which changes the message wording.
         is_random = False
         is_blame_suggestion = False
+        blame_reviewer_slack_ids: list[str] = []
 
-        # If no reviewers assigned, prefer pre-computed suggestions (e.g. from
-        # git blame), filtered to current team members; otherwise pick randomly.
-        if not reviewer_slack_ids and team_members:
+        if reviewer_slack_ids:
+            # Reviewers are explicitly assigned. Keep them as the primary
+            # mention and surface blame suggestions as a secondary note, minus
+            # anyone already assigned.
+            assigned = set(reviewer_slack_ids)
+            for github_login in suggested:
+                blame_slack_id = get_id_from_mapping_path(
+                    github_login, github_login_to_slack_ids_path
+                )
+                if blame_slack_id and blame_slack_id not in assigned:
+                    blame_reviewer_slack_ids.append(blame_slack_id)
+        elif team_members:
+            # No reviewers assigned: prefer blame suggestions, else random pick.
             team_members_list = [
                 m for m in team_members if m != pull_request.user.login
             ]
-            suggested = [
-                login
-                for login in get_suggested_reviewers_for_team(
-                    team, suggested_reviewers_json_path
-                )
-                if login in team_members and login != pull_request.user.login
-            ]
-
             if suggested:
                 is_blame_suggestion = True
                 chosen = suggested
@@ -194,6 +215,7 @@ def process_review_request(  # noqa: PLR0917, PLR0914
             is_random_assignment=is_random,
             is_blame_suggestion=is_blame_suggestion,
             summary=summary,
+            blame_reviewers=blame_reviewer_slack_ids,
         )
         message = create_slack_message(review_request)
         if slack_id:

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -152,6 +152,23 @@ def test_create_slack_message_with_blame_suggestion(
     )
 
 
+def test_create_slack_message_with_blame_secondary_note(
+    mock_pull_request: PullRequest,
+) -> None:
+    review_request = ReviewRequest(
+        team="@Greenbax/test-team",
+        channel="test-channel",
+        slack_id="U123",
+        pull_request=mock_pull_request,
+        reviewers=["U_ALICE"],
+        blame_reviewers=["U_BOB"],
+    )
+    message = create_slack_message(review_request)
+    # Assigned reviewer stays primary; blame surfaces as a secondary note.
+    assert "(assigned to <@U_ALICE>)" in message
+    assert "<@U_BOB> recently touched these lines." in message
+
+
 def test_create_slack_message_with_single_reviewer(
     mock_pull_request: PullRequest,
 ) -> None:
@@ -301,6 +318,105 @@ def test_process_review_request_prefers_suggested_over_random(  # noqa: PLR0917
     mock_random.assert_not_called()
     message_text = mock_post_message.call_args.kwargs["text"]
     assert "since they recently touched these lines" in message_text
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch(
+    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
+)
+@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
+def test_process_review_request_shows_blame_note_with_assigned_reviewers(
+    mock_post_message: MagicMock,
+    mock_get_user_info: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_team: GithubTeam,
+    mock_pull_request: PullRequest,
+) -> None:
+    """Assigned reviewer stays primary; blame is added as a secondary note."""
+    mock_get_user_info.return_value = ("icon_url", "username")
+
+    alice = MagicMock()
+    alice.login = "alice"
+    bob = MagicMock()
+    bob.login = "bob"
+    mock_team.get_members = MagicMock(return_value=[alice, bob])  # type: ignore[method-assign]
+
+    def slack_id_lookup(github_login: str, _path: Path) -> str | None:
+        return {
+            "@Greenbax/test-team": "test-channel",
+            "alice": "U_ALICE",
+            "bob": "U_BOB",
+        }.get(github_login)
+
+    mock_get_slack_id.side_effect = slack_id_lookup
+
+    with patch(
+        "bar_raiser.autofixes.notify_reviewer_teams.get_suggested_reviewers_for_team",
+        return_value=["bob"],
+    ):
+        _comment, success = process_review_request(
+            mock_team,
+            mock_pull_request,
+            "U123",
+            dry_run="test-channel",
+            github_team_to_slack_channels_path=Path("test-path"),
+            github_team_to_slack_channels_help_msg="",
+            individual_reviewers=["alice"],
+            github_login_to_slack_ids_path=Path("test-path-login"),
+            suggested_reviewers_json_path=Path("suggested.json"),
+        )
+
+    assert success
+    message_text = mock_post_message.call_args.kwargs["text"]
+    assert "(assigned to <@U_ALICE>)" in message_text
+    assert "<@U_BOB> recently touched these lines." in message_text
+
+
+@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
+@patch(
+    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
+)
+@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
+def test_process_review_request_blame_note_excludes_assigned_overlap(
+    mock_post_message: MagicMock,
+    mock_get_user_info: MagicMock,
+    mock_get_slack_id: MagicMock,
+    mock_team: GithubTeam,
+    mock_pull_request: PullRequest,
+) -> None:
+    """A blame author already assigned isn't repeated in the secondary note."""
+    mock_get_user_info.return_value = ("icon_url", "username")
+
+    alice = MagicMock()
+    alice.login = "alice"
+    mock_team.get_members = MagicMock(return_value=[alice])  # type: ignore[method-assign]
+
+    def slack_id_lookup(github_login: str, _path: Path) -> str | None:
+        return {"@Greenbax/test-team": "test-channel", "alice": "U_ALICE"}.get(
+            github_login
+        )
+
+    mock_get_slack_id.side_effect = slack_id_lookup
+
+    with patch(
+        "bar_raiser.autofixes.notify_reviewer_teams.get_suggested_reviewers_for_team",
+        return_value=["alice"],
+    ):
+        _comment, success = process_review_request(
+            mock_team,
+            mock_pull_request,
+            "U123",
+            dry_run="test-channel",
+            github_team_to_slack_channels_path=Path("test-path"),
+            github_team_to_slack_channels_help_msg="",
+            individual_reviewers=["alice"],
+            github_login_to_slack_ids_path=Path("test-path-login"),
+            suggested_reviewers_json_path=Path("suggested.json"),
+        )
+
+    assert success
+    message_text = mock_post_message.call_args.kwargs["text"]
+    assert "recently touched these lines" not in message_text
     assert "<@U_ALICE>" in message_text
     assert "U_BOB" not in message_text
 

--- a/tests/autofixes/test_notify_reviewer_teams.py
+++ b/tests/autofixes/test_notify_reviewer_teams.py
@@ -152,23 +152,6 @@ def test_create_slack_message_with_blame_suggestion(
     )
 
 
-def test_create_slack_message_with_blame_secondary_note(
-    mock_pull_request: PullRequest,
-) -> None:
-    review_request = ReviewRequest(
-        team="@Greenbax/test-team",
-        channel="test-channel",
-        slack_id="U123",
-        pull_request=mock_pull_request,
-        reviewers=["U_ALICE"],
-        blame_reviewers=["U_BOB"],
-    )
-    message = create_slack_message(review_request)
-    # Assigned reviewer stays primary; blame surfaces as a secondary note.
-    assert "(assigned to <@U_ALICE>)" in message
-    assert "<@U_BOB> recently touched these lines." in message
-
-
 def test_create_slack_message_with_single_reviewer(
     mock_pull_request: PullRequest,
 ) -> None:
@@ -325,14 +308,14 @@ def test_process_review_request_prefers_suggested_over_random(  # noqa: PLR0917
     "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
 )
 @patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
-def test_process_review_request_shows_blame_note_with_assigned_reviewers(
+def test_process_review_request_blame_overrides_assigned(
     mock_post_message: MagicMock,
     mock_get_user_info: MagicMock,
     mock_get_slack_id: MagicMock,
     mock_team: GithubTeam,
     mock_pull_request: PullRequest,
 ) -> None:
-    """Assigned reviewer stays primary; blame is added as a secondary note."""
+    """Blame suggestion overrides GitHub's assigned reviewer."""
     mock_get_user_info.return_value = ("icon_url", "username")
 
     alice = MagicMock()
@@ -350,6 +333,7 @@ def test_process_review_request_shows_blame_note_with_assigned_reviewers(
 
     mock_get_slack_id.side_effect = slack_id_lookup
 
+    # alice is GitHub's assigned reviewer, but blame points at bob.
     with patch(
         "bar_raiser.autofixes.notify_reviewer_teams.get_suggested_reviewers_for_team",
         return_value=["bob"],
@@ -368,57 +352,9 @@ def test_process_review_request_shows_blame_note_with_assigned_reviewers(
 
     assert success
     message_text = mock_post_message.call_args.kwargs["text"]
-    assert "(assigned to <@U_ALICE>)" in message_text
-    assert "<@U_BOB> recently touched these lines." in message_text
-
-
-@patch("bar_raiser.autofixes.notify_reviewer_teams.get_id_from_mapping_path")
-@patch(
-    "bar_raiser.autofixes.notify_reviewer_teams.get_slack_user_icon_url_and_username"
-)
-@patch("bar_raiser.autofixes.notify_reviewer_teams.post_a_slack_message")
-def test_process_review_request_blame_note_excludes_assigned_overlap(
-    mock_post_message: MagicMock,
-    mock_get_user_info: MagicMock,
-    mock_get_slack_id: MagicMock,
-    mock_team: GithubTeam,
-    mock_pull_request: PullRequest,
-) -> None:
-    """A blame author already assigned isn't repeated in the secondary note."""
-    mock_get_user_info.return_value = ("icon_url", "username")
-
-    alice = MagicMock()
-    alice.login = "alice"
-    mock_team.get_members = MagicMock(return_value=[alice])  # type: ignore[method-assign]
-
-    def slack_id_lookup(github_login: str, _path: Path) -> str | None:
-        return {"@Greenbax/test-team": "test-channel", "alice": "U_ALICE"}.get(
-            github_login
-        )
-
-    mock_get_slack_id.side_effect = slack_id_lookup
-
-    with patch(
-        "bar_raiser.autofixes.notify_reviewer_teams.get_suggested_reviewers_for_team",
-        return_value=["alice"],
-    ):
-        _comment, success = process_review_request(
-            mock_team,
-            mock_pull_request,
-            "U123",
-            dry_run="test-channel",
-            github_team_to_slack_channels_path=Path("test-path"),
-            github_team_to_slack_channels_help_msg="",
-            individual_reviewers=["alice"],
-            github_login_to_slack_ids_path=Path("test-path-login"),
-            suggested_reviewers_json_path=Path("suggested.json"),
-        )
-
-    assert success
-    message_text = mock_post_message.call_args.kwargs["text"]
-    assert "recently touched these lines" not in message_text
-    assert "<@U_ALICE>" in message_text
-    assert "U_BOB" not in message_text
+    # Blame (bob) wins, with the "recently touched" wording; alice is dropped.
+    assert "<@U_BOB> since they recently touched these lines" in message_text
+    assert "U_ALICE" not in message_text
 
 
 @patch(


### PR DESCRIPTION
## Summary

Reviewer precedence in the notification is now: **git blame > GitHub assigned reviewers > random**.

Before, the git-blame suggestion only filled in when a team had no assigned reviewer; GitHub's round-robin assignee pre-empted it. Per discussion with Jimmy, blame is the stronger signal and should win:

- GitHub auto-assignment is round-robin/random, weaker than "who last touched these lines".
- The assigned reviewer already got GitHub's own notification; if they haven't reviewed, they likely lack context.
- Any team member's approval satisfies the required CODEOWNERS check, so overriding the notification's suggestion doesn't block anything.

So when blame has a suggestion for a team, the message uses it and drops the round-robin assignee:

```
A review from the *infra* team (maybe @bob since they recently touched these lines) is required. Thanks\! 🙏
```

When blame finds nobody, it falls back to the assigned reviewer ("assigned to @alice"), then to a random pick — both unchanged.

### What's in the PR

`process_review_request` resolves blame suggestions first and promotes them over `individual_reviewers`; the assigned/random paths are the fallbacks. This replaces the earlier secondary-note approach (showing blame alongside the assignee) and removes the `blame_reviewers` field.

## Test plan

Updated tests: blame overrides an assigned reviewer; assigned and random fallbacks still render their wording. Full suite passes (63), ruff and pyright clean.
